### PR TITLE
Update to .NET 8.0

### DIFF
--- a/Sample/MauiProgram.cs
+++ b/Sample/MauiProgram.cs
@@ -1,4 +1,4 @@
-﻿using Prism.DryIoc;
+﻿using Prism.Container.DryIoc;
 using Shiny;
 using Prism.Navigation;
 

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>Sample</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -39,8 +39,9 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\src\Shiny.Framework\Shiny.Framework.csproj" />
-		<PackageReference Include="Prism.DryIoc.Maui" Version="8.1.273-pre" />
+		<PackageReference Include="Prism.DryIoc.Maui" Version="9.0.271-pre" />
 		<PackageReference Include="ReactiveUI.Fody" Version="19.4.1" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-rc.2.9373" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Shiny.Framework/BaseServices.cs
+++ b/src/Shiny.Framework/BaseServices.cs
@@ -2,6 +2,7 @@
 using Shiny.Net;
 using Shiny.Stores;
 using Microsoft.Extensions.Localization;
+using Prism.Navigation;
 
 namespace Shiny;
 

--- a/src/Shiny.Framework/BaseViewModel.cs
+++ b/src/Shiny.Framework/BaseViewModel.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
+using Prism.Navigation;
 using ReactiveUI;
 using Shiny.Net;
 using Shiny.Stores;

--- a/src/Shiny.Framework/Extensions_Maui.cs
+++ b/src/Shiny.Framework/Extensions_Maui.cs
@@ -8,6 +8,8 @@ using Microsoft.Maui.Hosting;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Extensions.DependencyInjection;
 using CommunityToolkit.Maui;
+using Prism.Ioc;
+using Prism;
 
 namespace Shiny;
 

--- a/src/Shiny.Framework/Extensions_Prism.cs
+++ b/src/Shiny.Framework/Extensions_Prism.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using Prism.Navigation;
 using ReactiveUI;
 using Shiny.Reflection;
 

--- a/src/Shiny.Framework/IGlobalNavigationService.cs
+++ b/src/Shiny.Framework/IGlobalNavigationService.cs
@@ -1,4 +1,6 @@
-﻿namespace Shiny;
+﻿using Prism.Navigation;
+
+namespace Shiny;
 
 
 public interface IGlobalNavigationService : INavigationService

--- a/src/Shiny.Framework/Impl/GlobalNavigationService.cs
+++ b/src/Shiny.Framework/Impl/GlobalNavigationService.cs
@@ -2,12 +2,12 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Prism.Common;
+using Prism.Ioc;
+using Prism.Navigation;
 using Prism.Navigation.Xaml;
-using Shiny;
 
 namespace Shiny.Impl;
 

--- a/src/Shiny.Framework/Impl/NativeDialogs.cs
+++ b/src/Shiny.Framework/Impl/NativeDialogs.cs
@@ -6,8 +6,11 @@ using CommunityToolkit.Maui.Core;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
+using Prism.AppModel;
 using Prism.Common;
+using Prism.Ioc;
 using Prism.Navigation.Xaml;
+using Prism.Services;
 using Font = Microsoft.Maui.Font;
 using SB = CommunityToolkit.Maui.Alerts.Snackbar;
 

--- a/src/Shiny.Framework/Shiny.Framework.csproj
+++ b/src/Shiny.Framework/Shiny.Framework.csproj
@@ -3,8 +3,8 @@
 	<PropertyGroup>
 		<Description>A collection of libraries and classes to make Xamarin, Shiny, RXUI, and Prism play beautifully together</Description>
 		
-		<TargetFrameworks>net7.0;net7.0-ios;net7.0-maccatalyst;net7.0-android</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-android</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
 
 		<RootNamespace>Shiny</RootNamespace>
@@ -58,9 +58,10 @@
 		<PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.0" />
 		<PackageReference Include="Shiny.Core" Version="$(ShinyVersion)" />
 		<PackageReference Include="Shiny.Support.DeviceMonitoring" Version="$(ShinyVersion)" />
-		<PackageReference Include="Prism.Maui" Version="8.1.273-pre" />
+		<PackageReference Include="Prism.Maui" Version="9.0.271-pre" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
 		<PackageReference Include="ReactiveUI" Version="19.4.1" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-rc.2.9373" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(IsPlatform)' == 'true'">

--- a/src/Shiny.Framework/ViewModel.cs
+++ b/src/Shiny.Framework/ViewModel.cs
@@ -1,6 +1,8 @@
 ﻿using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using Prism.AppModel;
+using Prism.Navigation;
 using ReactiveUI;
 
 namespace Shiny;

--- a/tests/Shiny.Framework.Tests/Shiny.Framework.Tests.csproj
+++ b/tests/Shiny.Framework.Tests/Shiny.Framework.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -18,7 +18,7 @@
         <PackageReference Include="DryIoc.dll" Version="5.4.1" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="ReactiveUI.Fody" Version="19.4.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rc.2.23479.6" />
     </ItemGroup>
 
     <!--


### PR DESCRIPTION
This updates Shiny Framework to use Prism 9.0 and .NET 8.0. 